### PR TITLE
Remove spurious quote at the beginning of the file

### DIFF
--- a/includes/modules/certificate-builder/includes/admin/class-llms-certificate-post-editor.php
+++ b/includes/modules/certificate-builder/includes/admin/class-llms-certificate-post-editor.php
@@ -1,4 +1,4 @@
-'<?php
+<?php
 /**
  * Post Table/Editor extensions
  *


### PR DESCRIPTION
It might (and does) cause the classic `PHP Warning:  Cannot modify header information - headers already sent by`
